### PR TITLE
Fixes #15 Docker container not starting correctly

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,13 +1,13 @@
-FROM python:3
+FROM python:3-slim-bullseye
 
 WORKDIR /usr/src/app
-
-RUN apt install git -y
-
-RUN git clone https://github.com/Pfuenzle/anime-loads.git
+RUN apt update && apt install git wget libgl1-mesa-glx libdbus-glib-1-2 libgtk-3-0 lbzip2 -y && apt clean && git clone https://github.com/Pfuenzle/anime-loads.git
 
 WORKDIR /usr/src/app/anime-loads
-
+RUN wget -nv https://github.com/mozilla/geckodriver/releases/download/v0.29.1/geckodriver-v0.29.1-linux64.tar.gz && tar -xf geckodriver-v0.29.1-linux64.tar.gz \
+&& wget -nv https://download-installer.cdn.mozilla.net/pub/firefox/releases/78.13.0esr/linux-x86_64/de/firefox-78.13.0esr.tar.bz2 && tar -xf firefox-78.13.0esr.tar.bz2 \
+&& rm geckodriver-v0.29.1-linux64.tar.gz && rm firefox-78.13.0esr.tar.bz2 && mv geckodriver /bin/geckodriver && chmod +x /bin/geckodriver
 RUN pip install --no-cache-dir -r requirements.txt
 
-CMD [ "python", "./anibot.py" ]
+ENTRYPOINT [ "python", "anibot.py" ]
+CMD [ "--docker" ]

--- a/README.md
+++ b/README.md
@@ -75,13 +75,13 @@ Container pullen:
 
 Falls noch keine Config existiert:
 
-    - docker run --rm -it -v $PWD/config:/config pfuenzle/anime-loads --interactive
+    - docker run --rm -it -v $PWD/config:/usr/src/app/anime-loads/config pfuenzle/anime-loads --interactive
 
 andernfalls einen Ordner "config" erstellen und eine bereits vorhandene ani.json reinverschieben
 
 Container starten (-it durch -dit ersetzen, um den Container im Hintergrund zu starten:
 
-    - docker run --rm -it -v $PWD/config:/config pfuenzle/anime-loads
+    - docker run --rm -it -v $PWD/config:/usr/src/app/anime-loads/config pfuenzle/anime-loads
 
 Docker-compose:
 ```
@@ -92,17 +92,17 @@ services:
     image: pfuenzle/anime-loads:latest
     container_name: anime-loads
     volumes:
-      - ./config:/config
+      - ./config:/usr/src/app/anime-loads/config
     restart: unless-stopped
 ```
 
 Config ändern:
 
-    - docker run --rm -it -v $PWD/config:/config pfuenzle/anime-loads add
+    - docker run --rm -it -v $PWD/config:/usr/src/app/anime-loads/config pfuenzle/anime-loads add
 
-    - docker run --rm -it -v $PWD/config:/config pfuenzle/anime-loads edit
+    - docker run --rm -it -v $PWD/config:/usr/src/app/anime-loads/config pfuenzle/anime-loads edit
 
-    - docker run --rm -it -v $PWD/config:/config pfuenzle/anime-loads remove
+    - docker run --rm -it -v $PWD/config:/usr/src/app/anime-loads/config pfuenzle/anime-loads remove
 
 
 ### downloader.py:


### PR DESCRIPTION
Hey,

Ich war mal so frei das Dockerimage zu überarbeiten, da dies bei mir aufgrund mehrerer Fehler überhaupt nicht laufen wollte:
- Einige shared Libraries haben gefehlt
- Geckodriver konnte nicht gefunden werden (in der anibot.py wird Firefox bei Docker enforced)
- ..Firefox konnte nicht gefunden werden
Außerdem habe ich das Base-Image auf ein Slim-Image umgestellt, damit es nicht wesentlich größer wird trotz der ganzen zusätzlichen Dependencies.
Da die anibot.py als CMD und nicht als Entrypoint ausgeführt wurde, haben außerdem die Befehle zum Config editieren (add / edit / remove) aus der Readme nicht funktioniert, weil damit der gesamte Befehl "py anibot..." überschrieben und somit versucht wurde den Shell-Befehl "add" etc. auszuführen. Dies ist nun ebenfalls angepasst.

Ebenfalls habe ich die chromedriver-zip entfernt, da die Binary dazu sowieso im Repo liegt und somit nur redundant ist.

Weitere Überlegungen die ich nicht umgesetzt habe, da ich nicht genau weiß wie du das Handhaben möchtest:
- Wäre es eventuell sinnvoller, die Chromedriver-Binary komplett aus dem Repository zu entfernen, da sie sonst jeder mit klonen "muss", selbst wenn Firefox mit Geckodriver genutzt werden soll? (Das könnte das Docker-Image nochmal um 10 MB verkleinern :D)
- Sollte der Ordner __pycache__ eventuell ebenfalls entfernt werden, da er keinen wirklichen Mehrwert hat?

TODO:
- Sobald Docker genutzt wird, sollte als Browserlocation `/usr/src/app/anime-loads/firefox/firefox` vorgegeben werden, damit sichergestellt ist, dass die FF executable gefunden wird.