### PR TITLE
Chromedriver-Entfernung.. entfernt.

### DIFF
--- a/docker/amd64+arm64/Dockerfile
+++ b/docker/amd64+arm64/Dockerfile
@@ -11,8 +11,7 @@ WORKDIR /usr/src/app/anime-loads
 RUN wget -nv https://github.com/mozilla/geckodriver/releases/download/v0.30.0/geckodriver-v0.30.0-linux64.tar.gz && tar -xf geckodriver-v0.30.0-linux64.tar.gz \
 && rm geckodriver-v0.30.0-linux64.tar.gz \
 && mv geckodriver /bin/geckodriver \
-&& chmod +x /bin/geckodriver \
-&& rm -rf chromedriver*
+&& chmod +x /bin/geckodriver
 RUN pip install --no-cache-dir -r requirements.txt
 
 ENTRYPOINT [ "python", "anibot.py", "--configfile", "/config/ani.json" ]

--- a/docker/arm7/Dockerfile
+++ b/docker/arm7/Dockerfile
@@ -11,8 +11,7 @@ WORKDIR /usr/src/app/anime-loads
 RUN wget -nv https://github.com/mozilla/geckodriver/releases/download/v0.23.0/geckodriver-v0.23.0-arm7hf.tar.gz && tar -xf geckodriver-v0.23.0-arm7hf.tar.gz \
 && rm geckodriver-v0.23.0-arm7hf.tar.gz \
 && mv geckodriver /bin/geckodriver \
-&& chmod +x /bin/geckodriver \
-&& rm -rf chromedriver*
+&& chmod +x /bin/geckodriver
 
 RUN sed -i 's/numpy/numpy==1.21.1/g' requirements.txt
 RUN pip install --extra-index-url https://www.piwheels.org/simple --no-cache-dir -r requirements.txt


### PR DESCRIPTION
Im Dockerimage war noch die Zeile zum Chromedrive löschen drin, damit das Image etwas kleiner ist. Da der Chromedriver nicht mehr im Image ist, wird die Zeile auch nicht mehr benötigt.

Ändert nichts am Image, aber so ists ordentlicher :^)