### PR TITLE
Added destinationFolder to config

### DIFF
--- a/anibot.py
+++ b/anibot.py
@@ -660,6 +660,10 @@ def startbot():
                 except:
                     customPackage = ""
                 try:
+                    destinationFolder = animeentry['destinationFolder']
+                except:
+                    destinationFolder = None
+                try:
                     anime = al.getAnime(url)
                     release = anime.getReleases()[releaseID-1]
                 except:
@@ -704,7 +708,7 @@ def startbot():
                         print("[DOWNLOAD] Lade episode " + str(i) + " von " + name)
                         try:
                             if(myjd_user != ""):
-                                dl_ret = anime.downloadEpisode(i, release, hoster, browser, browserlocation, myjd_user=myjd_user, myjd_pw=myjd_pass, myjd_device=myjd_device, pkgName=customPackage)
+                                dl_ret = anime.downloadEpisode(i, release, hoster, browser, browserlocation, myjd_user=myjd_user, myjd_pw=myjd_pass, myjd_device=myjd_device, pkgName=customPackage, destinationFolder=destinationFolder)
                             else:
                                 dl_ret = anime.downloadEpisode(i, release, hoster, browser, browserlocation, jdhost, pkgName=customPackage)
                         except Exception as e:

--- a/animeloads.py
+++ b/animeloads.py
@@ -237,7 +237,7 @@ class utils:
             return True
 
     @staticmethod
-    def addToMYJD(myjd_user, myjd_pass, myjd_device, links, pkgName, pwd):
+    def addToMYJD(myjd_user, myjd_pass, myjd_device, links, pkgName, pwd, destinationFolder=None):
         jd=myjdapi.Myjdapi()
         jd.set_app_key("animeloads")
         jd.connect(myjd_user, myjd_pass)
@@ -254,7 +254,7 @@ class utils:
                               "extractPassword": pwd,
                               "priority": "DEFAULT",
                               "downloadPassword": None,
-                              "destinationFolder": None,
+                              "destinationFolder": destinationFolder,
                               "overwritePackagizerRules": False
                           }])
 


### PR DESCRIPTION
Ermöglicht ein Zielverzeichnis für die Downloads über MyJDownloader an JDownloader zu übergeben.

Beispiel Config:
```
{
    "anime": [
        {
            "customPackage": "Platinum End",
            "destinationFolder": "H:\\Medien\\Animes\\Platinum End\\Staffel 01",
            "episodes": 5,
            "missing": [],
            "name": "Platinum End",
            "releaseID": 2,
            "url": "https://www.anime-loads.org/media/platinum-end"
        }
}
```
Closes #17