### PR TITLE
Added not-interactive flag

### DIFF
--- a/anibot.py
+++ b/anibot.py
@@ -584,9 +584,11 @@ def startbot():
 
     jdhost, hoster, browser, browserlocation, pushkey, timedelay, myjd_user, myjd_pass, myjd_device = loadconfig()
  
-    interactive = True
-    if "--docker" in sys.argv and "--interactive" not in sys.argv:
+    interactive = "--docker" not in sys.argv
+    if "--not-interactive" in sys.argv:
         interactive = False
+    if "--interactive" in sys.argv:
+        interactive = True
 
     while(jdhost == False):
         if(interactive):


### PR DESCRIPTION
Ich habe ein Argument eingebaut um anibot nicht interaktiv starten zu können ohne das --docker Argument mit angeben zu müssen.

Neues Flag: --not-interactive

Die alten Funktionen und Standardwerte sollten hiervon nicht beeinflusst werden.

Closes #25 