### PR TITLE
Fix wrong hoster --> link assignment

### DIFF
--- a/animeloads.py
+++ b/animeloads.py
@@ -980,18 +980,16 @@ return xhr.response"
                 elif(key == "reflink"):
                     reflinks = value
                 elif(key == "content"):
-                    try:
-                        content_uploaded = value[0]
-                    except:
-                        pass
-                    try:
-                        content_ddl = value[1]
-                    except:
-                        pass
-                    try:
-                        content_rapid = value[2]
-                    except:
-                        pass
+                    for item in value:
+                        try:
+                            if item['hoster'] == "uploaded":
+                                content_uploaded = item
+                            elif item['hoster'] == "ddownload":
+                                content_ddl = item
+                            elif item['hoster'] == "rapidgator":
+                                content_rapid = item
+                        except:
+                            pass
             tries += 1
             
 #            raise ALCaptchaException("Captcha is needed to get download links")


### PR DESCRIPTION
when not all hoster are present the assignement of the link to the hoster are shifted and wrong links (or no links) are sent to jdownloader